### PR TITLE
feat(hc-pagopa): phishing section icon

### DIFF
--- a/hc_pagopa/assets/show-categories-icon.js
+++ b/hc_pagopa/assets/show-categories-icon.js
@@ -6,7 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const iconMap = {
     32550674474641: 'fa-solid fa-credit-card', // Come pagare con pagoPA
     31957404459025: 'fa-solid fa-triangle-exclamation', // Problemi con il pagamento
-    31957401197969: 'fa-solid fa-receipt' // Esito del pagamento rimborsi e ricevute
+    31957401197969: 'fa-solid fa-receipt', // Esito del pagamento rimborsi e ricevute
+    34448853492113: 'fa-solid fa-shield-halved' // Phishing e altre truffe online
   };
 
   // Func to extract ID from URL

--- a/hc_pagopa/manifest.json
+++ b/hc_pagopa/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "pagopa-help-center",
   "author": "PagoPa S.p.A.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "api_version": 2,
   "default_locale": "it",
   "settings": [


### PR DESCRIPTION
<!-- ![IO Brand](https://img.shields.io/badge/brand-IO-blue) -->
![pagopa Brand](https://img.shields.io/badge/brand-pagopa-BBDDFF)
<!-- ![SEND Brand](https://img.shields.io/badge/brand-SEND-163ee3) -->
<!-- ![Home Brand](https://img.shields.io/badge/brand-Home-orange) -->

### What type of PR is this?

- [ ] 🔨 Refactor
- [x] ✨ Feature
- [ ] ⛑️ Bug Fix
- [ ] 🚀 Optimization
- [ ] 📄 Documentation Update
- [ ] ⚠️ Breaking change [ℹ️](## "Fix or feature that would cause existing functionality to not work as expected")

### List of Changes
- [pagoPA] add icon for the new 'Phishing' section

### Related Task
- CACI-391

### How Has This Been Tested?
- Local tests

### Screenshots (if appropriate)
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/79eab067-a95b-4610-833a-575a7097c804" />
